### PR TITLE
FAM-1050 - Не выбрасывать exception когда нет ntpd

### DIFF
--- a/functional/terrain/libs/server.py
+++ b/functional/terrain/libs/server.py
@@ -33,8 +33,7 @@ SCALARIZR_LOG_IGNORE_ERRORS = [
     'p2p_message',
     'Caught exception reading instance data',
     'Expected list, got null. Selector: listvolumesresponse',
-    'error was thrown due to the hostname format',
-    'Unable to synchronize time, cause ntpdate binary is not found' # FAM-1050
+    'error was thrown due to the hostname format'
 ]
 
 # Run powershell script as Administrator


### PR DESCRIPTION
Removed ntp traceback from **Revizor Tests** (in verify_scalarizr_log)