### PR TITLE
Lifecycle windows - removed step exist chef_result_file 

### DIFF
--- a/functional/lifecycle/lifecycle_windows.feature
+++ b/functional/lifecycle/lifecycle_windows.feature
@@ -87,7 +87,6 @@ Feature: Windows server lifecycle
         And wait all servers are terminated
         Then I start farm
         And I expect server bootstrapping as M1
-        And file 'C:\chef_result_file' exist in M1 windows
         And hostname in M1 is valid
 
     @ec2 @gce @openstack @azure


### PR DESCRIPTION
На сервері файлу немає, бо в попередніх сценаріях він не створювався.